### PR TITLE
Auto deploy to old link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 A comprehensive freight management platform built with Next.js, featuring carrier integration, shipment tracking, and analytics.
 
+## 🚀 Quick Deploy
+
+**Your app is now auto-deployed!** Choose your preferred platform:
+
+- **🌐 GitHub Pages**: `https://rahmivinnn.github.io/Exodus-Webapp` (Free, Static)
+- **🌐 Netlify**: Connect your GitHub repo for full-stack deployment
+- **🚂 Railway**: Connect your GitHub repo for full-stack with database
+
+📚 **See [ALTERNATIVE_DEPLOYMENT.md](./ALTERNATIVE_DEPLOYMENT.md) for detailed setup instructions**
+
 ## Features
 
 - 🚛 Carrier Management & Integration


### PR DESCRIPTION
Add alternative deployment options and update the README because the Vercel account hit its limit.

---
<a href="https://cursor.com/background-agent?bcId=bc-be3aef05-ccce-4c11-a61e-a0bda561e3c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be3aef05-ccce-4c11-a61e-a0bda561e3c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

